### PR TITLE
Example of checking for actual instance before throwing

### DIFF
--- a/src/Dapper.NodaTime/InstantHandler.cs
+++ b/src/Dapper.NodaTime/InstantHandler.cs
@@ -29,6 +29,10 @@ namespace Dapper.NodaTime
 
         public override Instant Parse(object value)
         {
+            if (value is Instant) {
+                return (Instant)value;
+            }
+
             if (value is DateTime dateTime)
             {
                 var dt = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);


### PR DESCRIPTION
Im trying to use this library but I cannot because it is throwing the rather bizarre error:

System.Data.DataException: Error parsing column 3 (application_date=2016-06-21T23:00:00Z - Object) ---> System.Data.DataException: Cannot convert NodaTime.Instant to NodaTime.Instant
When used in conjunction with 

NpgsqlConnection.GlobalTypeMapper.UseNodaTime();

(.net core 2.1)

So I have created a PR demonstrating a simple fix to check if the type you are being passed is already the type you need. Hope its useful.