### PR TITLE
Update to Dapper version 2

### DIFF
--- a/src/Dapper.NodaTime/Dapper.NodaTime.csproj
+++ b/src/Dapper.NodaTime/Dapper.NodaTime.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides Noda Time support for Dapper</Description>
     <Authors>Matt Johnson</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageId>Dapper-NodaTime</PackageId>
     <PackageTags>dapper;nodatime;noda time</PackageTags>
     <PackageProjectUrl>https://github.com/mj1856/Dapper-NodaTime</PackageProjectUrl>
@@ -15,11 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.0.0" />
-    <PackageReference Include="Dapper" Version="1.50.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="Dapper" Version="2.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapper.NodaTime/DbDataParameterExtensions.cs
+++ b/src/Dapper.NodaTime/DbDataParameterExtensions.cs
@@ -1,0 +1,18 @@
+using System.Data;
+
+namespace Dapper.NodaTime
+{
+    internal static class DbDataParameterExtensions
+    {
+        public static void SetSqlDbType(this IDbDataParameter parameter, SqlDbType sqlDbType)
+        {
+            // Using reflection so as not to impose a choice on the SqlClient library, letting the consumer choose
+            // between System.Data.SqlClient or Microsoft.Data.SqlClient which both support the SqlDbType property
+            var property = parameter.GetType().GetProperty("SqlDbType");
+            if (property != null && property.CanWrite && property.PropertyType == typeof(SqlDbType))
+            {
+                property.SetValue(parameter, sqlDbType);
+            }
+        }
+    }
+}

--- a/src/Dapper.NodaTime/InstantHandler.cs
+++ b/src/Dapper.NodaTime/InstantHandler.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
 using NodaTime;
-
-#if NETSTANDARD1_3
-using DataException = System.InvalidOperationException;
-#endif
 
 namespace Dapper.NodaTime
 {
@@ -20,11 +15,7 @@ namespace Dapper.NodaTime
         public override void SetValue(IDbDataParameter parameter, Instant value)
         {
             parameter.Value = value.ToDateTimeUtc();
-
-            if (parameter is SqlParameter sqlParameter)
-            {
-                sqlParameter.SqlDbType = SqlDbType.DateTime2;
-            }
+            parameter.SetSqlDbType(SqlDbType.DateTime2);
         }
 
         public override Instant Parse(object value)

--- a/src/Dapper.NodaTime/LocalDateHandler.cs
+++ b/src/Dapper.NodaTime/LocalDateHandler.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
 using NodaTime;
-
-#if NETSTANDARD1_3
-using DataException = System.InvalidOperationException;
-#endif
 
 namespace Dapper.NodaTime
 {
@@ -20,11 +15,7 @@ namespace Dapper.NodaTime
         public override void SetValue(IDbDataParameter parameter, LocalDate value)
         {
             parameter.Value = value.AtMidnight().ToDateTimeUnspecified();
-
-            if (parameter is SqlParameter sqlParameter)
-            {
-                sqlParameter.SqlDbType = SqlDbType.Date;
-            }
+            parameter.SetSqlDbType(SqlDbType.Date);
         }
 
         public override LocalDate Parse(object value)

--- a/src/Dapper.NodaTime/LocalDateTimeHandler.cs
+++ b/src/Dapper.NodaTime/LocalDateTimeHandler.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
 using NodaTime;
-
-#if NETSTANDARD1_3
-using DataException = System.InvalidOperationException;
-#endif
 
 namespace Dapper.NodaTime
 {
@@ -20,11 +15,7 @@ namespace Dapper.NodaTime
         public override void SetValue(IDbDataParameter parameter, LocalDateTime value)
         {
             parameter.Value = value.ToDateTimeUnspecified();
-
-            if (parameter is SqlParameter sqlParameter)
-            {
-                sqlParameter.SqlDbType = SqlDbType.DateTime2;
-            }
+            parameter.SetSqlDbType(SqlDbType.DateTime2);
         }
 
         public override LocalDateTime Parse(object value)

--- a/src/Dapper.NodaTime/LocalTimeHandler.cs
+++ b/src/Dapper.NodaTime/LocalTimeHandler.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
 using NodaTime;
-
-#if NETSTANDARD1_3
-using DataException = System.InvalidOperationException;
-#endif
 
 namespace Dapper.NodaTime
 {
@@ -20,11 +15,7 @@ namespace Dapper.NodaTime
         public override void SetValue(IDbDataParameter parameter, LocalTime value)
         {
             parameter.Value = TimeSpan.FromTicks(value.TickOfDay);
-
-            if (parameter is SqlParameter sqlParameter)
-            {
-                sqlParameter.SqlDbType = SqlDbType.Time;
-            }
+            parameter.SetSqlDbType(SqlDbType.Time);
         }
 
         public override LocalTime Parse(object value)

--- a/src/Dapper.NodaTime/OffsetDateTimeHandler.cs
+++ b/src/Dapper.NodaTime/OffsetDateTimeHandler.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
 using NodaTime;
-
-#if NETSTANDARD1_3
-using DataException = System.InvalidOperationException;
-#endif
 
 namespace Dapper.NodaTime
 {
@@ -20,11 +15,7 @@ namespace Dapper.NodaTime
         public override void SetValue(IDbDataParameter parameter, OffsetDateTime value)
         {
             parameter.Value = value.ToDateTimeOffset();
-
-            if (parameter is SqlParameter sqlParameter)
-            {
-                sqlParameter.SqlDbType = SqlDbType.DateTimeOffset;
-            }
+            parameter.SetSqlDbType(SqlDbType.DateTimeOffset);
         }
 
         public override OffsetDateTime Parse(object value)


### PR DESCRIPTION
* Drop support for .NET Standard 1.3 and update net45 to net461 (to match Dapper requirements)
* Do not take a dependency on System.Data.SqlClient, let the consumer choose between System.Data.SqlClient or Microsoft.Data.SqlClient